### PR TITLE
Make symlink relative

### DIFF
--- a/styles/src/mc-car/layers
+++ b/styles/src/mc-car/layers
@@ -1,1 +1,1 @@
-/home/markov/code/sailfish/osmscout/mapbox-gl-styles/styles/src/osmbright-car/layers
+../osmbright-car/layers

--- a/styles/src/mc/layers
+++ b/styles/src/mc/layers
@@ -1,1 +1,1 @@
-/home/markov/code/sailfish/osmscout/mapbox-gl-styles/styles/src/osmbright/layers
+../osmbright/layers


### PR DESCRIPTION
So you don't have to have mapbox-gl-styles checked out in a specific directory in order to build the mc and mc-car styles